### PR TITLE
Update testing to reflect target of id

### DIFF
--- a/src/Login/Login.test.js
+++ b/src/Login/Login.test.js
@@ -15,14 +15,14 @@ describe('Login', () => {
 
   it('should have a default state', () => {
     expect(wrapper.state().user).toBe('');
-    expect(wrapper.state().favoriteQuote).toBe('');
+    expect(wrapper.state().quote).toBe('');
     expect(wrapper.state().ranking).toBe('Novice');
   });
 
   it('should update state with a new user when handleChange is invoked', () => {
     const mockEvent = {
       target : {
-        name: "user",
+        id: "user",
         value: "thatPamIAm"
       }
     }
@@ -37,22 +37,22 @@ describe('Login', () => {
   it('should update state with a new quote when handleChange is invoked', () => {
     const mockEvent = {
       target : {
-        name: "favoriteQuote",
+        id: "quote",
         value: "I find your lack of faith disturbing."
       }
     }
 
-    expect(wrapper.state().favoriteQuote).toBe('');
+    expect(wrapper.state().quote).toBe('');
 
     wrapper.instance().handleChange(mockEvent);
 
-    expect(wrapper.state().favoriteQuote).toBe('I find your lack of faith disturbing.');
+    expect(wrapper.state().quote).toBe('I find your lack of faith disturbing.');
   });
 
   it('should update state with a ranking level when handleChange is invoked', () => {
     const mockEvent = {
       target : {
-        name: "ranking",
+        id: "ranking",
         value: "Expert"
       }
     }


### PR DESCRIPTION
#### What's this PR do?
This PR updates the tests to reflect that the state property of `favoriteQuote` is now `quote`. It is also updated to show that `handleChange` should be targeting the id instead of the name attribute.

#### Where should the reviewer start?
`Login.test.js`

#### How should this be manually tested?
`npm test`

#### Any background context you want to provide?
The changes to the id attribue and state property were made in a preivous PR where styling was being addressed.
