### PR TITLE
Add opening crawl for movie/:id route

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -1,1 +1,3 @@
-
+.space-holder {
+  height: 100px;
+}

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router-dom';
 
 import Main from '../Main/Main';
 import Header from '../Header/Header';
+import './App.css';
 
 class App extends Component {
   constructor() {
@@ -33,9 +34,11 @@ class App extends Component {
   render() {
     return (
       <div className="App">
+        <div className="space-holder">
         {this.state.userInfo &&
-        <Header user={this.state.userInfo}
-                logOutUser={this.logOutUser} /> }
+          <Header user={this.state.userInfo}
+                  logOutUser={this.logOutUser} /> }
+          </div>
         <Main logInUser={this.logInUser} />
       </div>
     )

--- a/src/CharacterContainer/CharacterContainer.js
+++ b/src/CharacterContainer/CharacterContainer.js
@@ -11,7 +11,7 @@ class CharacterContainer extends Component {
   }
 
   componentDidMount() {
-    this.fetchCharacters(this.props.characters)
+    this.fetchCharacters(this.props.urls)
   }
 
   async fetchCharacters(list) {
@@ -23,7 +23,7 @@ class CharacterContainer extends Component {
   )
 
   this.setState({
-    characters: characters
+    characters
   })
  }
 

--- a/src/Main/Main.js
+++ b/src/Main/Main.js
@@ -3,6 +3,7 @@ import { Switch, Route, withRouter } from 'react-router-dom';
 
 import Login from '../Login/Login';
 import CharacterContainer from '../CharacterContainer/CharacterContainer';
+import OpeningCrawl from '../OpeningCrawl/OpeningCrawl';
 import MovieContainer from '../MovieContainer/MovieContainer';
 
 class Main extends Component{
@@ -11,6 +12,7 @@ class Main extends Component{
     this.state = {
       movies: [],
       urls: [],
+      crawl: {}
     }
     this.viewCharacters = this.viewCharacters.bind(this);
   }
@@ -20,18 +22,29 @@ class Main extends Component{
   }
 
   viewCharacters(id) {
-    const urls = this.findCharacters(id);
+    const urls = this.findCharacterUrls(id);
+    const crawl = this.findCrawlInfo(id);
     
     this.setState({
-      urls
+      urls,
+      crawl
     });
 
     this.props.history.push('/movies/' + id)
   }
 
-  findCharacters(id) {
+  findCharacterUrls(id) {
     return this.state.movies.find(movie => movie.episode_id === id)
       .characters;
+  }
+
+  findCrawlInfo(id) {
+    const movie = this.state.movies.find(movie => movie.episode_id === id);
+
+    return {
+      title: movie.title,
+      text: movie.opening_crawl
+    }
   }
 
   async fetchMovies(url) {
@@ -66,7 +79,8 @@ class Main extends Component{
             <MovieContainer movies={this.state.movies} viewCharacters={this.viewCharacters} />
           </Route>
           <Route path={"/movies/:" + this.state.movieId}>
-            <CharacterContainer characters={this.state.urls} />
+            <OpeningCrawl crawl={this.state.crawl}/>
+            <CharacterContainer urls={this.state.urls} />
           </Route>
         </Switch>
       </div>

--- a/src/Movie/Movie.css
+++ b/src/Movie/Movie.css
@@ -2,7 +2,7 @@
   background-color: #d6dfe8;
   color: #0d0b0f;
   height: 375px;
-  margin: 150px 0;
+  margin: 250px 0;
   text-align: center;
   width: 400px;
 }

--- a/src/OpeningCrawl/OpeningCrawl.css
+++ b/src/OpeningCrawl/OpeningCrawl.css
@@ -1,0 +1,36 @@
+.star-wars {
+  background-image: url(https://i.imgur.com/ThRRcRg.jpg);
+  background-size: cover;
+  box-shadow:0 3px 6px #7A7A7A;
+  color: #feda4a;
+  display: flex;
+  font-family: 'Pathway Gothic One', sans-serif;
+  font-size: 400%;
+  font-weight: 600;
+  height: 200px;
+  letter-spacing: 6px;
+  line-height: 150%;
+  perspective: 400px;
+  position: fixed;
+  overflow: hidden;
+
+}
+
+.crawl {
+  animation: crawl 60s linear;
+  position: relative;
+  top: 9999px;
+  transform-origin: 50% 100%;
+  text-align: center;
+}
+
+@keyframes crawl {
+  0% {
+    top: 0;
+    transform: rotateX(20deg)  translateZ(0);
+  }
+  100% { 
+    top: -6000px;
+    transform: rotateX(25deg) translateZ(-2500px);
+  }
+}

--- a/src/OpeningCrawl/OpeningCrawl.js
+++ b/src/OpeningCrawl/OpeningCrawl.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import './OpeningCrawl.css';
+
+function OpeningCrawl(props) {
+  return(
+    <section className="star-wars">
+      <div className="crawl">  
+        <h1>{props.crawl.title}</h1>
+        <p>{props.crawl.text}</p>
+      </div>
+    </section>
+  )
+}
+export default OpeningCrawl;


### PR DESCRIPTION
#### What's this PR do?
This PR addresses the functionality for when a user hits the `View Characters` button. When pressed, the opening crawl for the selected movie will play and all the characters for that movie will render.

There are also some small updates to naming for fetching the urls for characters.
 
#### Where should the reviewer start?

App.js
#### How should this be manually tested?
`npm test`

#### Any background context you want to provide?
Will add another issue - when a user is routed from MovieContainer to CharcacterContainer, the view/focus of the container should start at the top. 

The GIF below shows a user scrolling on MovieContainer, then routing to CharacterContainer with the focus of the container not starting at the top

#### What are the relevant tickets?
#8 

#### GIF
![Opening Crawl](https://media.giphy.com/media/MFDHiemk6CB639yRIY/giphy.gif)
